### PR TITLE
feat: add script to prune old Firebase secret versions

### DIFF
--- a/scripts/prune-old-secrets.sh
+++ b/scripts/prune-old-secrets.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+DEFAULT_APPS=("auth-provider" "auth-client")
+
+DRY_RUN=false
+KEEP_VERSIONS=1
+declare -a SELECTED_APPS=()
+
+TOTAL_VERSIONS_PRUNED=0
+LAST_PRUNED_COUNT=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/prune-old-secrets.sh [options]
+
+Deletes historic versions of Firebase / Secret Manager secrets for the auth apps.
+
+Options:
+  --dry-run           Only log the destroy commands; do not delete anything
+  --keep <count>      Number of newest versions to keep for each secret (default: 1)
+  --app <name>        Limit pruning to a specific app (can be provided multiple times)
+  -h, --help          Show this help message
+
+Examples:
+  scripts/prune-old-secrets.sh
+  scripts/prune-old-secrets.sh --dry-run
+  scripts/prune-old-secrets.sh --keep 2 --app auth-provider
+EOF
+}
+
+log_info() {
+  echo "ℹ️  $1"
+}
+
+log_success() {
+  echo "✅ $1"
+}
+
+log_warning() {
+  echo "⚠️  $1"
+}
+
+log_error() {
+  echo "❌ $1"
+}
+
+log_step() {
+  echo "🔧 $1"
+}
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "Required command '$cmd' not found in PATH"
+    exit 1
+  fi
+}
+
+extract_project_id() {
+  local file="$1"
+  local project_id
+  project_id="$(grep -E 'local[[:space:]]+project_id=' "$file" | head -n1 | sed -E 's/.*local[[:space:]]+project_id="([^"]+)".*/\1/')"
+  if [[ -z "${project_id:-}" ]]; then
+    log_warning "Could not infer project_id from $file"
+    return 1
+  fi
+  echo "$project_id"
+}
+
+SECRET_IDS_ARRAY=()
+extract_secret_ids() {
+  local file="$1"
+  local array_line
+  array_line="$(grep -E '^SECRET_IDS=\(' "$file" | head -n1 | tr -d '\r')"
+  if [[ -z "${array_line:-}" ]]; then
+    log_warning "Could not find SECRET_IDS array in $file"
+    return 1
+  fi
+
+  local sanitized="${array_line#SECRET_IDS=}"
+  local parsed=()
+  eval "parsed=$sanitized"
+  SECRET_IDS_ARRAY=("${parsed[@]}")
+}
+
+validate_keep_value() {
+  local value="$1"
+  if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+    log_error "--keep must be a positive integer (received '$value')"
+    exit 1
+  fi
+
+  if (( value < 1 )); then
+    log_error "--keep must be at least 1 (received '$value')"
+    exit 1
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --keep)
+        if [[ $# -lt 2 ]]; then
+          log_error "--keep requires a numeric argument"
+          exit 1
+        fi
+        KEEP_VERSIONS="$2"
+        shift 2
+        ;;
+      --app)
+        if [[ $# -lt 2 ]]; then
+          log_error "--app requires a value"
+          exit 1
+        fi
+        SELECTED_APPS+=("$2")
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        log_error "Unknown argument: $1"
+        usage
+        exit 1
+        ;;
+    esac
+  done
+}
+
+prune_secret_versions() {
+  local app="$1"
+  local project_id="$2"
+  local secret_id="$3"
+  local keep="$4"
+
+  LAST_PRUNED_COUNT=0
+
+  local cmd_output
+  if ! cmd_output="$(
+    gcloud secrets versions list "$secret_id" \
+      --project="$project_id" \
+      --filter='state!="DESTROYED"' \
+      --sort-by=~createTime \
+      --format='value(name)' 2>/dev/null
+  )"; then
+    log_warning "Failed to list versions for secret '$secret_id' in project '$project_id'; skipping"
+    return
+  fi
+
+  local versions=()
+  if [[ -n "$cmd_output" ]]; then
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && versions+=("$line")
+    done <<<"$cmd_output"
+  fi
+
+  if [[ ${#versions[@]} -eq 0 ]]; then
+    log_warning "No accessible versions found for secret '$secret_id' in project '$project_id'; skipping"
+    return
+  fi
+
+  if [[ ${#versions[@]} -le keep ]]; then
+    log_info "Secret '$secret_id' already has ${#versions[@]} version(s); keeping $keep newest"
+    return
+  fi
+
+  local to_delete=("${versions[@]:$keep}")
+  local pruned=0
+
+  log_step "Pruning ${#to_delete[@]} old version(s) from '$secret_id' (keeping $keep newest)"
+
+  for version in "${to_delete[@]}"; do
+    if [[ "$DRY_RUN" == true ]]; then
+      log_info "[DRY RUN] Would destroy version $version for '$secret_id' in project '$project_id'"
+      ((pruned++))
+      continue
+    fi
+
+    if gcloud secrets versions destroy "$version" \
+      --secret="$secret_id" \
+      --project="$project_id" \
+      --quiet >/dev/null; then
+      log_info "Destroyed version $version for '$secret_id'"
+      ((pruned++))
+    else
+      log_warning "Failed to destroy version $version for '$secret_id'"
+    fi
+  done
+
+  LAST_PRUNED_COUNT=$pruned
+}
+
+process_app() {
+  local app="$1"
+  local script_path="$REPO_ROOT/$app/scripts/firebase-secrets.sh"
+
+  if [[ ! -f "$script_path" ]]; then
+    log_warning "Skipping app '$app' (missing $script_path)"
+    return
+  fi
+
+  local project_id
+  if ! project_id="$(extract_project_id "$script_path")"; then
+    log_warning "Skipping app '$app' (unable to determine project ID)"
+    return
+  fi
+
+  SECRET_IDS_ARRAY=()
+  if ! extract_secret_ids "$script_path"; then
+    log_warning "Skipping app '$app' (unable to parse SECRET_IDS)"
+    return
+  fi
+
+  if [[ ${#SECRET_IDS_ARRAY[@]} -eq 0 ]]; then
+    log_warning "No secret IDs defined for app '$app'; skipping"
+    return
+  fi
+
+  log_step "Processing app '$app' (project: $project_id)"
+
+  local app_pruned=0
+  for secret_id in "${SECRET_IDS_ARRAY[@]}"; do
+    prune_secret_versions "$app" "$project_id" "$secret_id" "$KEEP_VERSIONS"
+    if (( LAST_PRUNED_COUNT > 0 )); then
+      app_pruned=$((app_pruned + LAST_PRUNED_COUNT))
+      TOTAL_VERSIONS_PRUNED=$((TOTAL_VERSIONS_PRUNED + LAST_PRUNED_COUNT))
+    fi
+  done
+
+  if (( app_pruned > 0 )); then
+    if [[ "$DRY_RUN" == true ]]; then
+      log_success "App '$app': would prune $app_pruned version(s)"
+    else
+      log_success "App '$app': pruned $app_pruned version(s)"
+    fi
+  else
+    log_info "App '$app': no versions pruned"
+  fi
+}
+
+main() {
+  parse_args "$@"
+  validate_keep_value "$KEEP_VERSIONS"
+
+  if [[ ${#SELECTED_APPS[@]} -eq 0 ]]; then
+    SELECTED_APPS=("${DEFAULT_APPS[@]}")
+  fi
+
+  require_command gcloud
+
+  if [[ "$DRY_RUN" == true ]]; then
+    log_info "Running in dry-run mode; no secrets will be destroyed"
+  fi
+
+  for app in "${SELECTED_APPS[@]}"; do
+    process_app "$app"
+  done
+
+  if (( TOTAL_VERSIONS_PRUNED == 0 )); then
+    if [[ "$DRY_RUN" == true ]]; then
+      log_info "Dry run complete; nothing to prune"
+    else
+      log_info "No secret versions were pruned"
+    fi
+    return
+  fi
+
+  if [[ "$DRY_RUN" == true ]]; then
+    log_success "Dry run: would prune $TOTAL_VERSIONS_PRUNED secret version(s)"
+  else
+    log_success "Pruned $TOTAL_VERSIONS_PRUNED secret version(s)"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
fixes https://github.com/F3-Nation/f3-nation-auth/issues/6

<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

<!-- keep it simple, a sentence or two at most -->

Added a bash script to automatically prune old Firebase Secret Manager versions while keeping specified latest versions.

### 🔎 Details

<!--
This is the place to get in the weeds about what changed.
Consider linking out to project artifacts like:
- Jira issue(s)
- Slack post(s)
- Loom video(s)
- Figma design(s)
- etc.
-->

This PR introduces `scripts/prune-old-secrets.sh`, a bash script that:

- Automatically cleans up old Firebase Secret Manager versions
- Retains specified number of latest versions (default: 1)
- Supports dry-run mode to preview changes before execution
- Allows app-specific filtering to limit pruning to selected applications
- Provides comprehensive logging with emoji indicators for different message types
- Includes input validation and error handling
- Requires `gcloud` CLI tool for Secret Manager operations

Key features:
- `--dry-run` flag to preview changes without deletion
- `--keep <count>` option to specify how many newest versions to retain (default: 1)
- `--app <name>` flag to limit pruning to specific applications
- Comprehensive error handling and user-friendly output

This helps maintain security by automatically removing outdated secret versions and reduces storage costs in Firebase projects.

### ✅ How to Test

<!--
Document what a real testing looks like.
Think not only about code review,
but also about QA/UAT.
Given-When-Then acceptance criteria are great,
but even just a flat list of common test cases
in common language is better than nothing
-->

1. **Dry Run Test**: Run `scripts/prune-old-secrets.sh --dry-run` to see what would be deleted without making changes
2. **Specific App Test**: Test with a single app: `scripts/prune-old-secrets.sh --app auth-provider --dry-run`
3. **Version Retention Test**: Test keeping multiple versions: `scripts/prune-old-secrets.sh --keep 2 --dry-run`
4. **Help Test**: Verify help text: `scripts/prune-old-secrets.sh --help`
5. **Validation Test**: Test error handling with invalid inputs: `scripts/prune-old-secrets.sh --keep 0` (should fail)
6. **Actual Execution**: After reviewing dry-run output, run without `--dry-run` to perform actual pruning (use with caution)
7. **Missing App Test**: Test with non-existent app: `scripts/prune-old-secrets.sh --app nonexistent-app --dry-run`

Ensure you have `gcloud` CLI installed and authenticated before testing actual deletion.

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
