### PR TITLE
fix: Wrap email signIn calls in try-catch to handle expected errors

### DIFF
--- a/auth-provider/app/login/email/page.tsx
+++ b/auth-provider/app/login/email/page.tsx
@@ -45,11 +45,18 @@ function EmailLoginContent() {
 
     try {
       // First step: send verification email
-      const result = await signIn('email', {
-        email,
-        callbackUrl,
-        redirect: false,
-      });
+      let result;
+      try {
+        result = await signIn('email', {
+          email,
+          callbackUrl,
+          redirect: false,
+        });
+      } catch (signInError) {
+        // next-auth may throw when parsing response with undefined url
+        // This is expected when authorize returns null after sending verification email
+        console.log('SignIn threw (expected for email verification step):', signInError);
+      }
 
       // When sending verification email, NextAuth returns null (not an error)
       // The error "CredentialsSignin" is expected for the first step

--- a/auth-provider/app/login/email/verify/page.tsx
+++ b/auth-provider/app/login/email/verify/page.tsx
@@ -132,11 +132,18 @@ function EmailVerifyContent() {
     setResendMessage(null);
     setIsResending(true);
     try {
-      const result = await signIn('email', {
-        email,
-        callbackUrl,
-        redirect: false,
-      });
+      let result;
+      try {
+        result = await signIn('email', {
+          email,
+          callbackUrl,
+          redirect: false,
+        });
+      } catch (signInError) {
+        // next-auth may throw when parsing response with undefined url
+        // This is expected when authorize returns null after sending verification email
+        console.log('SignIn threw (expected for email verification step):', signInError);
+      }
 
       if (result?.error && result.error !== 'CredentialsSignin') {
         setResendMessage({


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Wrapped NextAuth's `signIn('email')` calls in try-catch blocks to handle expected errors when sending verification emails, preventing UI crashes during the email login flow.

### 🔎 Details

NextAuth's email provider implementation can throw an error when parsing responses with undefined URLs during the verification email sending step. This is expected behavior when the `authorize` function returns `null` after successfully sending a verification email. Previously, these uncaught exceptions would crash the UI.

Changes made:
1. **`/app/login/email/page.tsx`**: Wrapped the initial `signIn('email')` call in a try-catch block to catch and log expected errors
2. **`/app/login/email/verify/page.tsx`**: Applied the same error handling pattern to the email resend functionality

The fix ensures that:
- Users can successfully request verification emails without encountering UI errors
- Email resend functionality works reliably
- Expected NextAuth behavior is properly handled without disrupting the user experience
- Error logging is maintained for debugging while preventing crashes

### ✅ How to Test

**Test Case 1: Initial Email Login**
1. Navigate to the email login page (`/login/email`)
2. Enter a valid email address and submit
3. Verify you're redirected to the verification page without any error popups
4. Check that the verification email is received

**Test Case 2: Email Resend Functionality**
1. Complete Test Case 1 to reach the verification page
2. Click the "Resend verification email" link
3. Verify the resend confirmation message appears
4. Check that a new verification email is received
5. Ensure no error messages disrupt the flow

**Test Case 3: Error Logging Verification**
1. Monitor browser console during both email send and resend operations
2. Verify that expected error messages are logged with the prefix "SignIn threw (expected for email verification step):"
3. Confirm these logged errors don't prevent successful email delivery

**Test Case 4: Integration with Existing Auth Flow**
1. Complete the email verification by clicking the link in the received email
2. Verify successful login and redirection to the intended callback URL
3. Test logout and repeat the flow to ensure consistency

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
