### PR TITLE
Add dedicated API endpoint for email verification

### DIFF
--- a/auth-provider/app/api/send-verification/route.ts
+++ b/auth-provider/app/api/send-verification/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createEmailVerification } from '@/lib/mfa';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { email, callbackUrl } = body;
+
+    if (!email || typeof email !== 'string') {
+      return NextResponse.json({ error: 'Email is required' }, { status: 400 });
+    }
+
+    // Basic email format validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return NextResponse.json({ error: 'Invalid email format' }, { status: 400 });
+    }
+
+    const resolvedCallbackUrl = callbackUrl || '/';
+
+    await createEmailVerification(email, resolvedCallbackUrl);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error sending verification email:', error);
+    return NextResponse.json(
+      { error: 'Failed to send verification email. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/auth-provider/app/login/email/page.tsx
+++ b/auth-provider/app/login/email/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { signIn } from 'next-auth/react';
 import ThemeImage from '../../components/ThemeImage';
 
 function EmailLoginContent() {
@@ -44,27 +43,21 @@ function EmailLoginContent() {
     }
 
     try {
-      // First step: send verification email
-      let result;
-      try {
-        result = await signIn('email', {
-          email,
-          callbackUrl,
-          redirect: false,
-        });
-      } catch (signInError) {
-        // next-auth may throw when parsing response with undefined url
-        // This is expected when authorize returns null after sending verification email
-        console.log('SignIn threw (expected for email verification step):', signInError);
-      }
+      // Send verification email via dedicated API endpoint
+      const response = await fetch('/api/send-verification', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, callbackUrl }),
+      });
 
-      // When sending verification email, NextAuth returns null (not an error)
-      // The error "CredentialsSignin" is expected for the first step
-      if (result?.error && result.error !== 'CredentialsSignin') {
-        setError(result.error);
+      const data = await response.json();
+
+      if (!response.ok) {
+        setError(data.error || 'Failed to send verification email');
       } else {
-        // Redirect to verification page regardless of the "CredentialsSignin" error
-        // This error is expected when just sending the verification email
+        // Redirect to verification page
         window.location.href = `/login/email/verify?email=${encodeURIComponent(email)}&callbackUrl=${encodeURIComponent(callbackUrl)}`;
       }
     } catch {

--- a/auth-provider/app/login/email/verify/page.tsx
+++ b/auth-provider/app/login/email/verify/page.tsx
@@ -132,23 +132,20 @@ function EmailVerifyContent() {
     setResendMessage(null);
     setIsResending(true);
     try {
-      let result;
-      try {
-        result = await signIn('email', {
-          email,
-          callbackUrl,
-          redirect: false,
-        });
-      } catch (signInError) {
-        // next-auth may throw when parsing response with undefined url
-        // This is expected when authorize returns null after sending verification email
-        console.log('SignIn threw (expected for email verification step):', signInError);
-      }
+      const response = await fetch('/api/send-verification', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, callbackUrl }),
+      });
 
-      if (result?.error && result.error !== 'CredentialsSignin') {
+      const data = await response.json();
+
+      if (!response.ok) {
         setResendMessage({
           type: 'error',
-          text: result.error,
+          text: data.error || 'Failed to resend verification code',
         });
       } else {
         setResendMessage({


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Added a dedicated API endpoint (`/api/send-verification`) to handle email verification requests.

### 🔎 Details

This PR introduces a new API endpoint for sending email verification codes:

1. **New API endpoint**: Created `/api/send-verification` route that validates email format and calls the existing `createEmailVerification` function

The new endpoint provides a dedicated interface for email verification operations, separating this functionality from the authentication flow.

### ✅ How to Test

1. **Test API endpoint directly**:
   - Send a POST request to `/api/send-verification` with valid JSON body
   - Verify successful response
   - Test with invalid inputs to confirm proper validation

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
