### PR TITLE
[auth-client] update firebase secrets project id

### DIFF
--- a/auth-client/scripts/firebase-secrets.sh
+++ b/auth-client/scripts/firebase-secrets.sh
@@ -2,17 +2,23 @@
 
 # Configuration constants
 SECRET_VARS=("NEXTAUTH_SECRET" "AUTH_PROVIDER_URL" "NEXTAUTH_URL" "NEXT_PUBLIC_NEXTAUTH_URL" "OAUTH_CLIENT_ID" "OAUTH_CLIENT_SECRET" "OAUTH_REDIRECT_URI")
-SECRET_IDS=("client-nextauth-secret" "client-auth-provider-url" "client-nextauth-url" "client-next-public-nextauth-url" "client-oauth-client-id" "client-oauth-client-secret" "client-oauth-redirect-uri")
+
+# Get secret IDs with environment-specific prefix (staging uses "staging-client-*", prod uses "client-*")
+get_secret_ids_for_env() {
+  local env="$1"
+  local prefix=""
+
+  if [[ "$env" == "staging" ]]; then
+    prefix="staging-"
+  fi
+
+  echo "${prefix}client-nextauth-secret ${prefix}client-auth-provider-url ${prefix}client-nextauth-url ${prefix}client-next-public-nextauth-url ${prefix}client-oauth-client-id ${prefix}client-oauth-client-secret ${prefix}client-oauth-redirect-uri"
+}
 
 # Environment-specific configurations
 get_project_id_for_env() {
-  local env="$1"
-
-  if [[ "$env" == "staging" ]]; then
-    echo "auth-client-staging"
-  else
-    echo "auth-client-prod"
-  fi
+  # Single Firebase project for all environments (same as auth-provider)
+  echo "f3-nation-auth"
 }
 
 get_backend_id_for_env() {
@@ -83,10 +89,15 @@ process_environment() {
   local project_id=$(get_project_id_for_env "$env")
   local backend_id=$(get_backend_id_for_env "$env")
   local env_file=$(get_env_file_for_env "$env" "$project_root")
+  local secret_ids_str=$(get_secret_ids_for_env "$env")
+
+  # Convert space-separated string to array
+  read -ra SECRET_IDS <<< "$secret_ids_str"
 
   log_info "Using project ID: $project_id"
   log_info "Using backend ID: $backend_id"
   log_info "Using env file: $env_file"
+  log_info "Secret prefix: $(if [[ "$env" == "staging" ]]; then echo "staging-client-*"; else echo "client-*"; fi)"
 
   # Set GCP project for this environment
   log_step "Setting GCP project to '$project_id'..."


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Updated the Firebase secrets management script to support environment-specific secret naming conventions, where staging environment secrets now use a `staging-client-*` prefix while production uses `client-*` prefix.

### 🔎 Details

The changes modify the `firebase-secrets.sh` script to handle environment-specific secret naming patterns required for proper secret isolation between staging and production environments. Key updates include:

1. **Removed hardcoded SECRET_IDS array** - The script now dynamically generates secret IDs based on the environment using a new `get_secret_ids_for_env()` function.

2. **Added environment-specific prefixing**:
   - Staging environment secrets now use `staging-client-*` prefix
   - Production environment secrets use `client-*` prefix (no prefix change)
   - This ensures proper namespace separation between environments

3. **Enhanced logging** - Added debug logging to show which secret prefix is being used for each environment run.

4. **Dynamic array construction** - The script now converts the space-separated secret IDs string into an array at runtime using `read -ra SECRET_IDS <<< "$secret_ids_str"`.

### ✅ How to Test

1. **Run the script for staging environment**:
   ```bash
   ./auth-client/scripts/firebase-secrets.sh staging
   ```
   - Verify logs show: `Secret prefix: staging-client-*`
   - Confirm secret operations target `staging-client-*` secrets in GCP Secret Manager

2. **Run the script for production environment**:
   ```bash
   ./auth-client/scripts/firebase-secrets.sh prod
   ```
   - Verify logs show: `Secret prefix: client-*`
   - Confirm secret operations target `client-*` secrets in GCP Secret Manager

3. **Test secret variable mapping**:
   - Ensure all 7 secret variables (`NEXTAUTH_SECRET`, `AUTH_PROVIDER_URL`, etc.) are properly mapped to their prefixed secret names
   - Verify the script doesn't break existing secret retrieval/update functionality

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
